### PR TITLE
Add display_query_parameters option for dashboard

### DIFF
--- a/vendor/github.com/spaceapegames/go-wavefront/dashboard.go
+++ b/vendor/github.com/spaceapegames/go-wavefront/dashboard.go
@@ -20,6 +20,9 @@ type Dashboard struct {
 	// Description is a description given to the Dashboard
 	Description string `json:"description"`
 
+	// Enable/Disable view of variables on dashboard
+	DisplayQueryParameters bool `json:"displayQueryParameters"`
+
 	// Url is the relative url to access the dashboard by on a cluster
 	Url string `json:"url"`
 

--- a/wavefront/resource_dashboard.go
+++ b/wavefront/resource_dashboard.go
@@ -394,6 +394,7 @@ func buildDashboard(d *schema.ResourceData) (*wavefront.Dashboard, error) {
 		Tags:             tags,
 		Description:      d.Get("description").(string),
 		Url:              d.Get("url").(string),
+                DisplayQueryParameters: d.Get("display_query_parameters").(bool),
 		Sections:         *buildSections(&terraformSections),
 		ParameterDetails: *buildParameterDetails(&terraformParams),
 	}, nil

--- a/wavefront/resource_dashboard.go
+++ b/wavefront/resource_dashboard.go
@@ -394,7 +394,7 @@ func buildDashboard(d *schema.ResourceData) (*wavefront.Dashboard, error) {
 		Tags:             tags,
 		Description:      d.Get("description").(string),
 		Url:              d.Get("url").(string),
-                DisplayQueryParameters: d.Get("display_query_parameters").(bool),
+		DisplayQueryParameters: d.Get("display_query_parameters").(bool),
 		Sections:         *buildSections(&terraformSections),
 		ParameterDetails: *buildParameterDetails(&terraformParams),
 	}, nil

--- a/wavefront/resource_dashboard.go
+++ b/wavefront/resource_dashboard.go
@@ -172,6 +172,10 @@ func resourceDashboard() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"display_query_parameters": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"section":           section,
 			"parameter_details": parameterDetail,
 			"tags": {
@@ -439,6 +443,7 @@ func resourceDashboardRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("name", dash.Name)
 	d.Set("description", dash.Description)
 	d.Set("url", dash.Url)
+	d.Set("display_query_parameters", dash.DisplayQueryParameters)
 
 	sections := []map[string]interface{}{}
 	for _, wavefrontSection := range dash.Sections {


### PR DESCRIPTION
Query parameters are always set to false.  The option adds the option to set it to true.